### PR TITLE
Upgrade node image to fix Critical Vulnerabilities, also fix schema failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,7 @@ RUN chmod 644 /etc/apt/sources.list.d/kubernetes.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update
-RUN apt-get install -y kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin awscli net-tools iputils-ping
-
-# Install sudo and add appuser to the sudo group
-RUN apt-get install -y sudo
-RUN useradd -m appuser && echo "appuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/appuser && chmod 440 /etc/sudoers.d/appuser
-RUN chown -R appuser /usr/local/app
+RUN apt-get install -y kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin awscli
 
 # Build the typescript code
 FROM base AS dependencies
@@ -30,6 +25,7 @@ RUN npm run build
 
 # Create the final production-ready image
 FROM base AS release
+RUN useradd -m appuser && chown -R appuser /usr/local/app
 ENV NODE_ENV=production
 RUN npm install --only=production
 COPY --from=dependencies /usr/local/app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS base
+FROM node:24.2.0-slim AS base
 WORKDIR /usr/local/app
 COPY package.json .
 
@@ -14,7 +14,12 @@ RUN chmod 644 /etc/apt/sources.list.d/kubernetes.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN apt-get update
-RUN apt-get install -y kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin awscli
+RUN apt-get install -y kubectl google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin awscli net-tools iputils-ping
+
+# Install sudo and add appuser to the sudo group
+RUN apt-get install -y sudo
+RUN useradd -m appuser && echo "appuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/appuser && chmod 440 /etc/sudoers.d/appuser
+RUN chown -R appuser /usr/local/app
 
 # Build the typescript code
 FROM base AS dependencies
@@ -25,7 +30,6 @@ RUN npm run build
 
 # Create the final production-ready image
 FROM base AS release
-RUN useradd -m appuser && chown -R appuser /usr/local/app
 ENV NODE_ENV=production
 RUN npm install --only=production
 COPY --from=dependencies /usr/local/app/dist ./dist

--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -26,18 +26,15 @@ export const kubectlDeleteSchema = {
       },
       labelSelector: {
         type: "string",
-        description: "Delete resources matching this label selector (e.g. 'app=nginx')",
-        optional: true
+        description: "Delete resources matching this label selector (e.g. 'app=nginx')"
       },
       manifest: { 
         type: "string", 
-        description: "YAML manifest defining resources to delete (optional)", 
-        optional: true
+        description: "YAML manifest defining resources to delete (optional)"
       },
       filename: { 
         type: "string", 
-        description: "Path to a YAML file to delete resources from (optional)", 
-        optional: true
+        description: "Path to a YAML file to delete resources from (optional)"
       },
       allNamespaces: {
         type: "boolean",
@@ -51,8 +48,7 @@ export const kubectlDeleteSchema = {
       },
       gracePeriodSeconds: {
         type: "number",
-        description: "Period of time in seconds given to the resource to terminate gracefully",
-        optional: true
+        description: "Period of time in seconds given to the resource to terminate gracefully"
       }
     },
     required: [],

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -14,42 +14,35 @@ export const kubectlGenericSchema = {
       },
       subCommand: {
         type: "string",
-        description: "Subcommand if applicable (e.g. 'history' for rollout)",
-        optional: true
+        description: "Subcommand if applicable (e.g. 'history' for rollout)"
       },
       resourceType: {
         type: "string",
-        description: "Resource type (e.g. pod, deployment)",
-        optional: true
+        description: "Resource type (e.g. pod, deployment)"
       },
       name: {
         type: "string",
-        description: "Resource name",
-        optional: true
+        description: "Resource name"
       },
       namespace: {
         type: "string",
         description: "Namespace",
-        default: "default",
-        optional: true
+        default: "default"
       },
       outputFormat: {
         type: "string",
         description: "Output format (e.g. json, yaml, wide)",
-        enum: ["json", "yaml", "wide", "name", "custom"],
-        optional: true
+        enum: ["json", "yaml", "wide", "name", "custom"]
       },
       flags: {
         type: "object",
         description: "Command flags as key-value pairs",
-        optional: true,
         additionalProperties: true
       },
       args: {
         type: "array",
         items: { type: "string" },
-        description: "Additional command arguments",
-        optional: true
+        description: "Additional command arguments"
       }
     },
     required: ["command"]

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -38,20 +38,17 @@ export const kubectlGetSchema = {
       },
       labelSelector: {
         type: "string",
-        description: "Filter resources by label selector (e.g. 'app=nginx')",
-        optional: true,
+        description: "Filter resources by label selector (e.g. 'app=nginx')"
       },
       fieldSelector: {
         type: "string",
         description:
-          "Filter resources by field selector (e.g. 'metadata.name=my-pod')",
-        optional: true,
+          "Filter resources by field selector (e.g. 'metadata.name=my-pod')"
       },
       sortBy: {
         type: "string",
         description:
-          "Sort events by a field (default: lastTimestamp). Only applicable for events.",
-        optional: true,
+          "Sort events by a field (default: lastTimestamp). Only applicable for events."
       },
     },
     required: ["resourceType"],

--- a/src/tools/kubectl-list.ts
+++ b/src/tools/kubectl-list.ts
@@ -31,13 +31,11 @@ export const kubectlListSchema = {
       },
       labelSelector: {
         type: "string",
-        description: "Filter resources by label selector (e.g. 'app=nginx')",
-        optional: true
+        description: "Filter resources by label selector (e.g. 'app=nginx')"
       },
       fieldSelector: {
         type: "string",
-        description: "Filter resources by field selector (e.g. 'metadata.name=my-pod')",
-        optional: true
+        description: "Filter resources by field selector (e.g. 'metadata.name=my-pod')"
       }
     },
     required: ["resourceType"],

--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -24,23 +24,19 @@ export const kubectlLogsSchema = {
       },
       container: {
         type: "string",
-        description: "Container name (required when pod has multiple containers)",
-        optional: true,
+        description: "Container name (required when pod has multiple containers)"
       },
       tail: {
         type: "number",
-        description: "Number of lines to show from end of logs",
-        optional: true,
+        description: "Number of lines to show from end of logs"
       },
       since: {
         type: "string",
-        description: "Show logs since relative time (e.g. '5s', '2m', '3h')",
-        optional: true,
+        description: "Show logs since relative time (e.g. '5s', '2m', '3h')"
       },
       sinceTime: {
         type: "string",
-        description: "Show logs since absolute time (RFC3339)",
-        optional: true,
+        description: "Show logs since absolute time (RFC3339)"
       },
       timestamps: {
         type: "boolean",
@@ -59,8 +55,7 @@ export const kubectlLogsSchema = {
       },
       labelSelector: {
         type: "string",
-        description: "Filter resources by label selector",
-        optional: true,
+        description: "Filter resources by label selector"
       }
     },
     required: ["resourceType", "name", "namespace"],

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -31,18 +31,15 @@ export const kubectlRolloutSchema = {
       },
       revision: {
         type: "number",
-        description: "Revision to rollback to (for undo subcommand)",
-        optional: true
+        description: "Revision to rollback to (for undo subcommand)"
       },
       toRevision: {
         type: "number",
-        description: "Revision to roll back to (for history subcommand)",
-        optional: true
+        description: "Revision to roll back to (for history subcommand)"
       },
       timeout: {
         type: "string",
-        description: "The length of time to wait before giving up (e.g., '30s', '1m', '2m30s')",
-        optional: true
+        description: "The length of time to wait before giving up (e.g., '30s', '1m', '2m30s')"
       },
       watch: {
         type: "boolean",


### PR DESCRIPTION
**Description**: This PR is to fix errors like below 
```
Failed to start the MCP server. {"command":"docker run -i --rm -v /Users/kkambhat/.kube/config:/root/.kube/config mcp/k8s","args":[],"error":"Invalid schema for tool kubectl_get: strict mode: unknown keyword: \"optional\"","stderr":"Starting Kubernetes MCP server v0.1.0, handling commands...\n"}
```
and also update the node image to ensure there are no Critical CVEs - 
node:22-bookworm-slim has severe vulnerabilities: https://hub.docker.com/layers/library/node/22-bookworm-slim/images/sha256-847a2a79a5190cae14a0617cfae5b61abea3f8bf0d914cd3cdf4bebfebd53803

All of these are fixed in node:24.2.0-slim
https://hub.docker.com/layers/library/node/24.2.0-slim/images/sha256-678bc2f5eae9131a3709bf1873609a65242b7156270c7b15f9c4e3a7b58caec9