### PR TITLE
Critical update: Add the non-optional fields to the required array.

### DIFF
--- a/src/tools/kubectl-delete.ts
+++ b/src/tools/kubectl-delete.ts
@@ -51,7 +51,7 @@ export const kubectlDeleteSchema = {
         description: "Period of time in seconds given to the resource to terminate gracefully"
       }
     },
-    required: [],
+    required: ["labelSelector", "manifest", "filename", "gracePeriodSeconds"],
   },
 } as const;
 

--- a/src/tools/kubectl-generic.ts
+++ b/src/tools/kubectl-generic.ts
@@ -45,7 +45,7 @@ export const kubectlGenericSchema = {
         description: "Additional command arguments"
       }
     },
-    required: ["command"]
+    required: ["command", "subCommand", "resourceType", "name", "namespace", "outputFormat", "flags", "args"]
   }
 };
 

--- a/src/tools/kubectl-get.ts
+++ b/src/tools/kubectl-get.ts
@@ -51,7 +51,7 @@ export const kubectlGetSchema = {
           "Sort events by a field (default: lastTimestamp). Only applicable for events."
       },
     },
-    required: ["resourceType"],
+    required: ["resourceType", "labelSelector", "fieldSelector", "sortBy"],
   },
 } as const;
 

--- a/src/tools/kubectl-list.ts
+++ b/src/tools/kubectl-list.ts
@@ -38,7 +38,7 @@ export const kubectlListSchema = {
         description: "Filter resources by field selector (e.g. 'metadata.name=my-pod')"
       }
     },
-    required: ["resourceType"],
+    required: ["resourceType", "labelSelector", "fieldSelector"],
   },
 } as const;
 

--- a/src/tools/kubectl-logs.ts
+++ b/src/tools/kubectl-logs.ts
@@ -58,7 +58,7 @@ export const kubectlLogsSchema = {
         description: "Filter resources by label selector"
       }
     },
-    required: ["resourceType", "name", "namespace"],
+    required: ["resourceType", "name", "namespace", "container", "tail", "since", "sinceTime", "labelSelector"],
   },
 } as const;
 

--- a/src/tools/kubectl-rollout.ts
+++ b/src/tools/kubectl-rollout.ts
@@ -47,7 +47,7 @@ export const kubectlRolloutSchema = {
         default: false
       }
     },
-    required: ["subCommand", "resourceType", "name"]
+    required: ["subCommand", "resourceType", "name", "revision", "toRevision", "timeout"]
   }
 };
 


### PR DESCRIPTION
I am integrating this MCP server with my Augment Code AI Agent in VSCode so that my AI assistant could use it as a tool. The MCP SDK likely enables strict mode by default for security and is the case for most of the top MCP Clients. The schema validation error occurs because the kubectl_get tool schema uses the non-standard "optional" keyword, which violates JSON Schema specifications enforced by Ajv's strict mode. Ajv's strict mode prevents silent schema errors but requires spec-compliant schemas. 

https://ajv.js.org/strict-mode.html
https://github.com/modelcontextprotocol/typescript-sdk/issues/400

Added the non-optional fields whose 'optional: true' was removed to the required array.